### PR TITLE
 add tri-state slider support

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -506,7 +506,7 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/ubuntu/fingerprint/init.fingerprint.rc:system/etc/init/init.fingerprint.rc \
     $(LOCAL_PATH)/ubuntu/recovery/ubports-mounter.sh:root/ubports-mounter.sh \
     $(LOCAL_PATH)/ubuntu/system/mount-android.conf:system/halium/etc/init/mount-android.conf \
-    $(LOCAL_PATH)/ubuntu/tri_state.py:system/halium/usr/share/tri_state_switch/tri_state.py
+    $(LOCAL_PATH)/ubuntu/tri_state.py:system/bin/tri_state.py
 
 
 #    libnetutils \

--- a/common.mk
+++ b/common.mk
@@ -505,7 +505,8 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/ubuntu/system/init.ubuntu.rc:system/etc/init/init.ubuntu.rc \
     $(LOCAL_PATH)/ubuntu/fingerprint/init.fingerprint.rc:system/etc/init/init.fingerprint.rc \
     $(LOCAL_PATH)/ubuntu/recovery/ubports-mounter.sh:root/ubports-mounter.sh \
-    $(LOCAL_PATH)/ubuntu/system/mount-android.conf:system/halium/etc/init/mount-android.conf
+    $(LOCAL_PATH)/ubuntu/system/mount-android.conf:system/halium/etc/init/mount-android.conf \
+    $(LOCAL_PATH)/ubuntu/tri_state.py:system/halium/usr/share/tri_state_switch/tri_state.py
 
 
 #    libnetutils \

--- a/ubuntu/70-dumpling.rules
+++ b/ubuntu/70-dumpling.rules
@@ -262,4 +262,4 @@ ACTION=="add", KERNEL=="block/platform/soc/7c4000.sdhci/by-name/frp", OWNER="sys
 ACTION=="add", KERNEL=="block/platform/soc/8804000.sdhci/by-name/frp", OWNER="system", GROUP="system", MODE="0600"
 ACTION=="add", KERNEL=="kmsg", OWNER="root", GROUP="system", MODE="0620"
 ACTION=="add", KERNEL=="msm_npu", OWNER="system", GROUP="system", MODE="0644"
-ACTION=="change", DEVPATH=="/devices/virtual/switch/tri-state-key", SUBSYSTEM=="switch", RUN+="/usr/bin/python3 /system/halium/usr/share/tri_state_switch/tri_state.py"
+ACTION=="change", DEVPATH=="/devices/virtual/switch/tri-state-key", SUBSYSTEM=="switch", RUN+="/usr/bin/python3 /system/bin/tri_state.py"

--- a/ubuntu/70-dumpling.rules
+++ b/ubuntu/70-dumpling.rules
@@ -262,4 +262,4 @@ ACTION=="add", KERNEL=="block/platform/soc/7c4000.sdhci/by-name/frp", OWNER="sys
 ACTION=="add", KERNEL=="block/platform/soc/8804000.sdhci/by-name/frp", OWNER="system", GROUP="system", MODE="0600"
 ACTION=="add", KERNEL=="kmsg", OWNER="root", GROUP="system", MODE="0620"
 ACTION=="add", KERNEL=="msm_npu", OWNER="system", GROUP="system", MODE="0644"
-
+ACTION=="change", DEVPATH=="/devices/virtual/switch/tri-state-key", SUBSYSTEM=="switch", RUN+="/usr/bin/python3 /system/halium/usr/share/tri_state_switch/tri_state.py"

--- a/ubuntu/tri_state.py
+++ b/ubuntu/tri_state.py
@@ -1,0 +1,16 @@
+#!/usr/bin/python3
+
+import os
+import dbus
+
+with open('/sys/class/switch/tri-state-key/state', 'r') as content_file:
+    state = int(content_file.read())
+
+    session = dbus.SystemBus()
+    proxy = session.get_object('org.freedesktop.Accounts','/org/freedesktop/Accounts/User32011')
+    interface = dbus.Interface(proxy,'org.freedesktop.DBus.Properties')
+
+    if state == 1:
+        interface.Set('com.ubuntu.touch.AccountsService.Sound','SilentMode',True)
+    else:
+        interface.Set('com.ubuntu.touch.AccountsService.Sound','SilentMode',False)


### PR DESCRIPTION
source : https://github.com/Halium/android_device_oneplus_oneplus3/commit/ed57864f9f2cb8dd6276e1d739cb200ba478d25c
support only two mode:
- vibration (only vibration) when the slider is up
- loud (alarm + vibration) otherwise

so currently no fully Silent mode (no alarm + no vibration)

Change-Id: Ia7f6e808931de235aa67b463558b789dbcac935e